### PR TITLE
Fixes #39 - Unexplained Crash with No Error Message

### DIFF
--- a/SOS/Domain/ErrorFunction.cpp
+++ b/SOS/Domain/ErrorFunction.cpp
@@ -48,16 +48,21 @@ namespace domain
 		return order;
 	}
 
-	void eval_one_day_of_test_case(static std::vector<unsigned int> & _individual_indexes, static unsigned long _row, unsigned int _test_case, bool _record_transactions)
+	void eval_one_day_of_test_case(static std::vector<int> & _individual_indexes, static unsigned long _row, unsigned int _test_case, bool _record_transactions)
 	{
 		std::map<order_types, unsigned int> orders = { {order_types::buy, 0}, {order_types::hold, 0}, {order_types::sell, 0} };
 		order_types order;
 
 		// Generate orders
-		for (unsigned int individual_index : _individual_indexes)
+		for (int individual_index : _individual_indexes)
 		{
-			order = run_individual_program(individual_index, _row);
-			orders[order]++;
+			if (individual_index >= 0)
+			{
+				order = run_individual_program(individual_index, _row);
+				orders[order]++;
+			}
+			else
+				orders[order_types::hold]++;
 		}
 
 		// Get the most popular order
@@ -90,7 +95,7 @@ namespace domain
 
 	// Evaluate a single test case
 //	double evaluate_individual(Individual & individual, unsigned long input_start, unsigned long input_end)
-	double evaluate_individuals(static std::vector<unsigned int> & _individual_indexes, static unsigned long _input_start, static unsigned long _input_end, unsigned int _test_case, bool _record_transactions)
+	double evaluate_individuals(static std::vector<int> & _individual_indexes, static unsigned long _input_start, static unsigned long _input_end, unsigned int _test_case, bool _record_transactions)
 	{
 		unsigned long day_index = 0;
 		Broker broker = Broker(argmap::opening_balance);
@@ -115,11 +120,11 @@ namespace domain
 
 	// epsilon-lexicase
 //	double lexicase_reproduction_selection_error_function(Individual & individual_, unsigned long input_start_, unsigned long input_end_)
-	double lexicase_reproduction_selection_error_function(static unsigned int individual_index, static unsigned long input_start_, static unsigned long input_end_)
+	double lexicase_reproduction_selection_error_function(static int individual_index, static unsigned long input_start_, static unsigned long input_end_)
 	{
 //		const unsigned int input_end = Broker::get_number_of_datatable_rows() - argmap::number_of_training_days_in_year - 1;
 		double min_error = std::numeric_limits<double>::max();
-		std::vector<unsigned int> individual_indexes = { individual_index };
+		std::vector<int> individual_indexes = { individual_index };
 
 		// Evaluate test cases
 		unsigned int test_case = 1;

--- a/SOS/Domain/ErrorFunction.h
+++ b/SOS/Domain/ErrorFunction.h
@@ -16,12 +16,12 @@ namespace domain
 	order_types run_individual_program(static unsigned int individual_index, static unsigned long input_row);
 
 	// Evaluates one day in a test case
-	void eval_one_day_of_test_case(static std::vector<unsigned int> & individual_indexes, static unsigned long input_row, unsigned int _test_case, bool _record_transactions);
+	void eval_one_day_of_test_case(static std::vector<int> & individual_indexes, static unsigned long input_row, unsigned int _test_case, bool _record_transactions);
 
 	// Evaluates an individual using the provided range
-	double evaluate_individuals(static std::vector<unsigned int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions);
+	double evaluate_individuals(static std::vector<int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions);
 
-	double lexicase_reproduction_selection_error_function(static unsigned int individual, static unsigned long input_start, static unsigned long input_end);
+	double lexicase_reproduction_selection_error_function(static int individual, static unsigned long input_start, static unsigned long input_end);
 
 	void load_argmap();
 }

--- a/SOS/PushGP/PushGP.cpp
+++ b/SOS/PushGP/PushGP.cpp
@@ -201,7 +201,7 @@ namespace pushGP
 	}
 
 	void generate_status_report(int generation_, 
-		std::function<double(static std::vector<unsigned int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function,
+		std::function<double(static std::vector<int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function,
 		unsigned int training_input_start, 
 		unsigned int training_input_end,
 		unsigned int test_input_start,
@@ -209,7 +209,7 @@ namespace pushGP
 	{
 		unsigned int n = 0;
 		double min_error = std::numeric_limits<double>::max();
-		unsigned int index_of_individual_with_best_training_score_for_all_data = 0;
+		int index_of_individual_with_best_training_score_for_all_data = 0;
 		database::SQLCommand* sqlcmd_save_status_report;
 
 		double training_score_of_individual_with_best_training_score_for_all_data = 0;
@@ -223,13 +223,13 @@ namespace pushGP
 		// Clear test case counts
 		min_error = std::numeric_limits<double>::max();
 
-		for (unsigned int individual_index = 0; individual_index < argmap::population_size; individual_index++)
+		for (int individual_index = 0; individual_index < argmap::population_size; individual_index++)
 		{
 			globals::population_agents[individual_index].clear_elite_test_cases();
 
 			std::cout << "Calculate the group training score for individual #" << individual_index + 1 << std::endl;
 
-			std::vector<unsigned int> individual_indexes = { individual_index };
+			std::vector<int> individual_indexes = { individual_index };
 
 			double error = individual_selection_error_function(individual_indexes, training_input_start, training_input_end, 0, false);
 
@@ -245,7 +245,7 @@ namespace pushGP
 		std::cout << "Group Training Score = " << training_score_of_individual_with_best_training_score_for_all_data << std::endl;
 
 		// Calculate the best individual's test score
-		std::vector<unsigned int> best_individual_indexes = { index_of_individual_with_best_training_score_for_all_data };
+		std::vector<int> best_individual_indexes = { index_of_individual_with_best_training_score_for_all_data };
 		double error = individual_selection_error_function(best_individual_indexes, test_input_start, test_input_end, 0, false);
 		validation_score_of_individual_with_best_training_score_for_all_data = 0.0 - error;
 
@@ -253,9 +253,9 @@ namespace pushGP
 
 		// Find the individual with the minimum error for each test case
 		std::vector<double> test_case_minimum_error(Number_Of_Test_Cases);
-		std::vector<unsigned int> index_of_best_individual_for_each_test_case(Number_Of_Test_Cases);
+		std::vector<int> index_of_best_individual_for_each_test_case(Number_Of_Test_Cases);
 		std::set<unsigned int> set_of_eligible_parents;
-		std::vector<unsigned int> index_of_eligible_parents;
+		std::vector<int> index_of_eligible_parents;
 
 		for (int test_case_index = 0; test_case_index < Number_Of_Test_Cases; test_case_index++)
 		{
@@ -281,7 +281,7 @@ namespace pushGP
 			}
 		}
 
-		for (unsigned int individual_index : set_of_eligible_parents)
+		for (int individual_index : set_of_eligible_parents)
 			index_of_eligible_parents.push_back(individual_index);
 
 		// Calculate the training error from the best individuals from each test case
@@ -305,7 +305,7 @@ namespace pushGP
 		std::cout << "Eligible parents test score = " << eligible_parents_validation_score << std::endl;
 
 		// Calculte group training score
-		std::vector<unsigned int> index_of_individuals;
+		std::vector<int> index_of_individuals;
 
 		for (int individual_index = 0; individual_index < argmap::population_size; individual_index++)
 			index_of_individuals.push_back(individual_index);
@@ -393,8 +393,8 @@ namespace pushGP
 		globals::population_agents[index_of_elite_individual_with_maximum_number_test_cases].dump_transactions();
 	}
 
-	void pushgp(std::function<double(unsigned int, unsigned long, unsigned long)> reproduction_selection_error_function,
-		        std::function<double(static std::vector<unsigned int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function)
+	void pushgp(std::function<double(int, unsigned long, unsigned long)> reproduction_selection_error_function,
+		        std::function<double(static std::vector<int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function)
 	{
 		try
 		{

--- a/SOS/PushGP/PushGP.h
+++ b/SOS/PushGP/PushGP.h
@@ -24,13 +24,13 @@ namespace pushGP
 	void save_generation();
 
 	void generate_status_report(int generation_, 
-		static std::function<double(static std::vector<unsigned int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function,
+		static std::function<double(static std::vector<int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function,
 		static unsigned int training_input_start, 
 		static unsigned int training_input_end, 
 		static unsigned int test_input_start, 
 		static unsigned int test_input_end);
 
 	// The top-level routine of pushgp
-	void pushgp(std::function<double(static unsigned int, static unsigned long, static unsigned long)> reproduction_selection_error_function,
-		        std::function<double(static std::vector<unsigned int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function);
+	void pushgp(std::function<double(static int, static unsigned long, static unsigned long)> reproduction_selection_error_function,
+		        std::function<double(static std::vector<int> & individual_indexes, static unsigned long input_start, static unsigned long input_end, unsigned int _test_case, bool _record_transactions)> individual_selection_error_function);
 }


### PR DESCRIPTION
Running the code in debug mode revealed that the crash was caused by run_individual_program() being called with a very large value for the individual_index parameter (4294967295). Tracing this back through the call stack showed that the large value was produced by a type cast conversion of -1 from int to unsigned int in eval_one_day_of_test_case(). The value of -1 was put in the list of individual indexes provided by generate_status_report() to mark test cases which do not have any solutions.

To fix the issue, I changed the collection of individual indexes from unsigned int to int and modified eval_one_day_of_test_case() to ignore index values of -1