### PR TITLE
Fixed #44 - Crash While Evaluating Individual 0

### DIFF
--- a/SOS/PushP/NumOps.h
+++ b/SOS/PushP/NumOps.h
@@ -174,7 +174,12 @@ namespace Push
 		}
 
 		int first = pop<int>(env);
-		get_stack<int>().back() %= first;
+		int second = get_stack<int>().back();
+		
+		// Check for integer overflow
+		if ((first != -1) || (second != INT_MIN))
+			second %= first;
+
 		return 1;
 	}
 


### PR DESCRIPTION
Added check for Integer Overflow in the INTEGER.% function.